### PR TITLE
Handle struct pointer checks in Evaluate

### DIFF
--- a/evaluator.go
+++ b/evaluator.go
@@ -8,6 +8,18 @@ import (
 	"strings"
 )
 
+func derefStructPtr(i interface{}) (reflect.Value, bool) {
+	v := reflect.ValueOf(i)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return reflect.Value{}, false
+	}
+	v = v.Elem()
+	if v.Kind() != reflect.Struct {
+		return reflect.Value{}, false
+	}
+	return v, true
+}
+
 type Expression interface {
 	Evaluate(i interface{}) bool
 }
@@ -18,8 +30,11 @@ type ContainsExpression struct {
 }
 
 func (e ContainsExpression) Evaluate(i interface{}) bool {
-	v := reflect.ValueOf(i)
-	f := v.Elem().FieldByName(e.Field)
+	v, ok := derefStructPtr(i)
+	if !ok {
+		return false
+	}
+	f := v.FieldByName(e.Field)
 	if !f.IsValid() {
 		return false
 	}
@@ -47,8 +62,11 @@ type IsNotExpression struct {
 }
 
 func (e IsNotExpression) Evaluate(i interface{}) bool {
-	v := reflect.ValueOf(i)
-	f := v.Elem().FieldByName(e.Field)
+	v, ok := derefStructPtr(i)
+	if !ok {
+		return false
+	}
+	f := v.FieldByName(e.Field)
 	if !f.IsValid() {
 		return false
 	}
@@ -61,8 +79,11 @@ type IsExpression struct {
 }
 
 func (e IsExpression) Evaluate(i interface{}) bool {
-	v := reflect.ValueOf(i)
-	f := v.Elem().FieldByName(e.Field)
+	v, ok := derefStructPtr(i)
+	if !ok {
+		return false
+	}
+	f := v.FieldByName(e.Field)
 	if !f.IsValid() {
 		return false
 	}
@@ -171,8 +192,11 @@ type GreaterThanExpression struct {
 }
 
 func (e GreaterThanExpression) Evaluate(i interface{}) bool {
-	v := reflect.ValueOf(i)
-	f := v.Elem().FieldByName(e.Field)
+	v, ok := derefStructPtr(i)
+	if !ok {
+		return false
+	}
+	f := v.FieldByName(e.Field)
 	if !f.IsValid() {
 		return false
 	}
@@ -209,8 +233,11 @@ type GreaterThanOrEqualExpression struct {
 }
 
 func (e GreaterThanOrEqualExpression) Evaluate(i interface{}) bool {
-	v := reflect.ValueOf(i)
-	f := v.Elem().FieldByName(e.Field)
+	v, ok := derefStructPtr(i)
+	if !ok {
+		return false
+	}
+	f := v.FieldByName(e.Field)
 	if !f.IsValid() {
 		return false
 	}
@@ -247,8 +274,11 @@ type LessThanExpression struct {
 }
 
 func (e LessThanExpression) Evaluate(i interface{}) bool {
-	v := reflect.ValueOf(i)
-	f := v.Elem().FieldByName(e.Field)
+	v, ok := derefStructPtr(i)
+	if !ok {
+		return false
+	}
+	f := v.FieldByName(e.Field)
 	if !f.IsValid() {
 		return false
 	}
@@ -285,8 +315,11 @@ type LessThanOrEqualExpression struct {
 }
 
 func (e LessThanOrEqualExpression) Evaluate(i interface{}) bool {
-	v := reflect.ValueOf(i)
-	f := v.Elem().FieldByName(e.Field)
+	v, ok := derefStructPtr(i)
+	if !ok {
+		return false
+	}
+	f := v.FieldByName(e.Field)
 	if !f.IsValid() {
 		return false
 	}

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -91,6 +91,16 @@ func TestLogicalExpressions(t *testing.T) {
 	}
 }
 
+func TestNonPointerInput(t *testing.T) {
+	u := testUser{Tags: []string{"a"}, Name: "bob"}
+	if (ContainsExpression{Field: "Tags", Value: "a"}).Evaluate(u) {
+		t.Errorf("expected false for non-pointer input")
+	}
+	if (IsExpression{Field: "Name", Value: "bob"}).Evaluate(u) {
+		t.Errorf("expected false for non-pointer input")
+	}
+}
+
 func TestQueryUnmarshalAndEvaluate(t *testing.T) {
 	js := `{
         "Expression": {


### PR DESCRIPTION
## Summary
- avoid panics on non-struct-pointer inputs by adding `derefStructPtr`
- update expression Evaluate methods to require a non-nil pointer to a struct
- add regression test verifying non-pointer input returns false

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6864697cbd88832fbbf84c54103fb87a