### PR TITLE
Add EditorConfig and Gitignore

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary and coverage reports
+*.test
+*.out
+coverage.*
+
+# Build output
+bin/
+build/
+dist/
+
+# Vendor directory
+vendor/
+
+# IDE/editor directories and files
+.idea/
+.vscode/
+*.swp
+*~
+.DS_Store


### PR DESCRIPTION
## Summary
- add standard `.editorconfig` for Go and YAML files
- add a `.gitignore` that ignores build artifacts, editor files and vendor directory

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68646bf3b254832f8acb1c29ba2c534f