### PR TITLE
Add aliases package for short expression names

### DIFF
--- a/aliases/aliases.go
+++ b/aliases/aliases.go
@@ -1,0 +1,39 @@
+package aliases
+
+import "github.com/arran4/go-evaluator"
+
+// Q is a short alias for evaluator.Query.
+type Q = evaluator.Query
+
+// Expr is a short alias for evaluator.Expression.
+type Expr = evaluator.Expression
+
+// EQ is a short alias for evaluator.IsExpression.
+type EQ = evaluator.IsExpression
+
+// NE is a short alias for evaluator.IsNotExpression.
+type NE = evaluator.IsNotExpression
+
+// GT is a short alias for evaluator.GreaterThanExpression.
+type GT = evaluator.GreaterThanExpression
+
+// GTE is a short alias for evaluator.GreaterThanOrEqualExpression.
+type GTE = evaluator.GreaterThanOrEqualExpression
+
+// LT is a short alias for evaluator.LessThanExpression.
+type LT = evaluator.LessThanExpression
+
+// LTE is a short alias for evaluator.LessThanOrEqualExpression.
+type LTE = evaluator.LessThanOrEqualExpression
+
+// CT is a short alias for evaluator.ContainsExpression.
+type CT = evaluator.ContainsExpression
+
+// AND is a short alias for evaluator.AndExpression.
+type AND = evaluator.AndExpression
+
+// OR is a short alias for evaluator.OrExpression.
+type OR = evaluator.OrExpression
+
+// NOT is a short alias for evaluator.NotExpression.
+type NOT = evaluator.NotExpression

--- a/aliases/aliases_test.go
+++ b/aliases/aliases_test.go
@@ -1,0 +1,18 @@
+package aliases_test
+
+import (
+	"testing"
+
+	aliases "github.com/arran4/go-evaluator/aliases"
+)
+
+type user struct {
+	Name string
+}
+
+func TestAliasesEvaluate(t *testing.T) {
+	q := aliases.Q{Expression: &aliases.EQ{Field: "Name", Value: "bob"}}
+	if !q.Evaluate(&user{Name: "bob"}) {
+		t.Fatalf("expected true")
+	}
+}


### PR DESCRIPTION
## Summary
- introduce new `aliases` package
- provide type aliases with short names such as `EQ` for equality checks
- add basic unit test for the alias package

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6865165caf88832f9fa78fc714a9bb7b