### PR TITLE
Add simple recursive parser

### DIFF
--- a/parser/simple/lexer.go
+++ b/parser/simple/lexer.go
@@ -1,0 +1,134 @@
+package simple
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+type tokenType int
+
+const (
+	tokenEOF tokenType = iota
+	tokenIdent
+	tokenString
+	tokenNumber
+	tokenAnd
+	tokenOr
+	tokenNot
+	tokenIs
+	tokenIsNot
+	tokenContains
+	tokenGT
+	tokenGTE
+	tokenLT
+	tokenLTE
+	tokenLParen
+	tokenRParen
+)
+
+type token struct {
+	typ tokenType
+	val string
+}
+
+func isDelim(r rune) bool {
+	return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_'
+}
+
+func lex(input string) ([]token, error) {
+	var tokens []token
+	i := 0
+	for i < len(input) {
+		r := rune(input[i])
+		if unicode.IsSpace(r) {
+			i++
+			continue
+		}
+
+		remain := input[i:]
+		switch {
+		case strings.HasPrefix(remain, "and") && (len(remain) == 3 || isDelim(rune(remain[3]))):
+			tokens = append(tokens, token{typ: tokenAnd, val: "and"})
+			i += 3
+			continue
+		case strings.HasPrefix(remain, "or") && (len(remain) == 2 || isDelim(rune(remain[2]))):
+			tokens = append(tokens, token{typ: tokenOr, val: "or"})
+			i += 2
+			continue
+		case strings.HasPrefix(remain, "not") && (len(remain) == 3 || isDelim(rune(remain[3]))):
+			tokens = append(tokens, token{typ: tokenNot, val: "not"})
+			i += 3
+			continue
+		case strings.HasPrefix(remain, "is not") && (len(remain) == 6 || isDelim(rune(remain[6]))):
+			tokens = append(tokens, token{typ: tokenIsNot, val: "is not"})
+			i += 6
+			continue
+		case strings.HasPrefix(remain, "is") && (len(remain) == 2 || isDelim(rune(remain[2]))):
+			tokens = append(tokens, token{typ: tokenIs, val: "is"})
+			i += 2
+			continue
+		case strings.HasPrefix(remain, "contains") && (len(remain) == 8 || isDelim(rune(remain[8]))):
+			tokens = append(tokens, token{typ: tokenContains, val: "contains"})
+			i += 8
+			continue
+		case strings.HasPrefix(remain, ">="):
+			tokens = append(tokens, token{typ: tokenGTE, val: ">="})
+			i += 2
+			continue
+		case strings.HasPrefix(remain, "<="):
+			tokens = append(tokens, token{typ: tokenLTE, val: "<="})
+			i += 2
+			continue
+		case strings.HasPrefix(remain, ">"):
+			tokens = append(tokens, token{typ: tokenGT, val: ">"})
+			i++
+			continue
+		case strings.HasPrefix(remain, "<"):
+			tokens = append(tokens, token{typ: tokenLT, val: "<"})
+			i++
+			continue
+		case strings.HasPrefix(remain, "("):
+			tokens = append(tokens, token{typ: tokenLParen, val: "("})
+			i++
+			continue
+		case strings.HasPrefix(remain, ")"):
+			tokens = append(tokens, token{typ: tokenRParen, val: ")"})
+			i++
+			continue
+		case remain[0] == '"':
+			j := 1
+			for i+j < len(input) && input[i+j] != '"' {
+				j++
+			}
+			if i+j >= len(input) {
+				return nil, fmt.Errorf("unterminated string")
+			}
+			tokens = append(tokens, token{typ: tokenString, val: input[i+1 : i+j]})
+			i += j + 1
+			continue
+		default:
+			if unicode.IsDigit(r) || (r == '.' && i+1 < len(input) && unicode.IsDigit(rune(input[i+1]))) {
+				j := 1
+				for i+j < len(input) && (unicode.IsDigit(rune(input[i+j])) || input[i+j] == '.') {
+					j++
+				}
+				tokens = append(tokens, token{typ: tokenIdent, val: input[i : i+j]})
+				i += j
+				continue
+			}
+			j := 0
+			for i+j < len(input) && !unicode.IsSpace(rune(input[i+j])) && !isDelim(rune(input[i+j])) {
+				j++
+			}
+			if j == 0 {
+				return nil, fmt.Errorf("unexpected character %q", input[i])
+			}
+			tokens = append(tokens, token{typ: tokenIdent, val: input[i : i+j]})
+			i += j
+			continue
+		}
+	}
+	tokens = append(tokens, token{typ: tokenEOF})
+	return tokens, nil
+}

--- a/parser/simple/parser.go
+++ b/parser/simple/parser.go
@@ -1,0 +1,221 @@
+package simple
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/arran4/go-evaluator"
+)
+
+// Parse converts the input expression string into a Query.
+func Parse(input string) (evaluator.Query, error) {
+	tokens, err := lex(input)
+	if err != nil {
+		return evaluator.Query{}, err
+	}
+	pos := 0
+	q, err := parseExpr(tokens, &pos)
+	if err != nil {
+		return evaluator.Query{}, err
+	}
+	if tokens[pos].typ != tokenEOF {
+		return evaluator.Query{}, fmt.Errorf("unexpected token %q", tokens[pos].val)
+	}
+	return q, nil
+}
+
+func parseExpr(ts []token, pos *int) (evaluator.Query, error) {
+	return parseOr(ts, pos)
+}
+
+func parseOr(ts []token, pos *int) (evaluator.Query, error) {
+	left, err := parseAnd(ts, pos)
+	if err != nil {
+		return evaluator.Query{}, err
+	}
+	for ts[*pos].typ == tokenOr {
+		*pos++
+		right, err := parseAnd(ts, pos)
+		if err != nil {
+			return evaluator.Query{}, err
+		}
+		left = evaluator.Query{Expression: &evaluator.OrExpression{Expressions: []evaluator.Query{left, right}}}
+	}
+	return left, nil
+}
+
+func parseAnd(ts []token, pos *int) (evaluator.Query, error) {
+	left, err := parseUnary(ts, pos)
+	if err != nil {
+		return evaluator.Query{}, err
+	}
+	for ts[*pos].typ == tokenAnd {
+		*pos++
+		right, err := parseUnary(ts, pos)
+		if err != nil {
+			return evaluator.Query{}, err
+		}
+		left = evaluator.Query{Expression: &evaluator.AndExpression{Expressions: []evaluator.Query{left, right}}}
+	}
+	return left, nil
+}
+
+func parseUnary(ts []token, pos *int) (evaluator.Query, error) {
+	if ts[*pos].typ == tokenNot {
+		*pos++
+		exp, err := parseUnary(ts, pos)
+		if err != nil {
+			return evaluator.Query{}, err
+		}
+		return evaluator.Query{Expression: &evaluator.NotExpression{Expression: exp}}, nil
+	}
+	return parsePrimary(ts, pos)
+}
+
+func parsePrimary(ts []token, pos *int) (evaluator.Query, error) {
+	if ts[*pos].typ == tokenLParen {
+		*pos++
+		q, err := parseExpr(ts, pos)
+		if err != nil {
+			return evaluator.Query{}, err
+		}
+		if ts[*pos].typ != tokenRParen {
+			return evaluator.Query{}, fmt.Errorf("expected )")
+		}
+		*pos++
+		return q, nil
+	}
+	return parseComparison(ts, pos)
+}
+
+func parseComparison(ts []token, pos *int) (evaluator.Query, error) {
+	if ts[*pos].typ != tokenIdent {
+		return evaluator.Query{}, fmt.Errorf("expected identifier")
+	}
+	field := ts[*pos].val
+	*pos++
+
+	tok := ts[*pos]
+	*pos++
+
+	var op tokenType
+	switch tok.typ {
+	case tokenIs, tokenIsNot, tokenContains, tokenGT, tokenGTE, tokenLT, tokenLTE:
+		op = tok.typ
+	default:
+		return evaluator.Query{}, fmt.Errorf("unexpected operator %q", tok.val)
+	}
+
+	valTok := ts[*pos]
+	*pos++
+	if valTok.typ != tokenIdent && valTok.typ != tokenString && valTok.typ != tokenNumber {
+		return evaluator.Query{}, fmt.Errorf("expected value")
+	}
+	val, err := tokenValue(valTok)
+	if err != nil {
+		return evaluator.Query{}, err
+	}
+
+	switch op {
+	case tokenIs:
+		return evaluator.Query{Expression: &evaluator.IsExpression{Field: field, Value: val}}, nil
+	case tokenIsNot:
+		return evaluator.Query{Expression: &evaluator.IsNotExpression{Field: field, Value: val}}, nil
+	case tokenContains:
+		return evaluator.Query{Expression: &evaluator.ContainsExpression{Field: field, Value: val}}, nil
+	case tokenGT:
+		return evaluator.Query{Expression: &evaluator.GreaterThanExpression{Field: field, Value: val}}, nil
+	case tokenGTE:
+		return evaluator.Query{Expression: &evaluator.GreaterThanOrEqualExpression{Field: field, Value: val}}, nil
+	case tokenLT:
+		return evaluator.Query{Expression: &evaluator.LessThanExpression{Field: field, Value: val}}, nil
+	case tokenLTE:
+		return evaluator.Query{Expression: &evaluator.LessThanOrEqualExpression{Field: field, Value: val}}, nil
+	default:
+		return evaluator.Query{}, fmt.Errorf("unknown operator")
+	}
+}
+
+func tokenValue(t token) (interface{}, error) {
+	switch t.typ {
+	case tokenString:
+		return t.val, nil
+	case tokenNumber:
+		// not used currently as lexer doesn't emit tokenNumber
+		return t.val, nil
+	case tokenIdent:
+		if t.val == "true" {
+			return true, nil
+		}
+		if t.val == "false" {
+			return false, nil
+		}
+		// number detection
+		if n, err := strconv.ParseInt(t.val, 10, 64); err == nil {
+			return int(n), nil
+		}
+		if f, err := strconv.ParseFloat(t.val, 64); err == nil {
+			return f, nil
+		}
+		return t.val, nil
+	default:
+		return nil, fmt.Errorf("invalid value token")
+	}
+}
+
+// Stringify returns a canonical expression string from a Query.
+func Stringify(q evaluator.Query) string {
+	if q.Expression == nil {
+		return ""
+	}
+	return stringifyExpr(q.Expression)
+}
+
+func stringifyExpr(e evaluator.Expression) string {
+	switch ex := e.(type) {
+	case *evaluator.ContainsExpression:
+		return ex.Field + " contains " + valToString(ex.Value)
+	case *evaluator.IsExpression:
+		return ex.Field + " is " + valToString(ex.Value)
+	case *evaluator.IsNotExpression:
+		return ex.Field + " is not " + valToString(ex.Value)
+	case *evaluator.GreaterThanExpression:
+		return ex.Field + " > " + valToString(ex.Value)
+	case *evaluator.GreaterThanOrEqualExpression:
+		return ex.Field + " >= " + valToString(ex.Value)
+	case *evaluator.LessThanExpression:
+		return ex.Field + " < " + valToString(ex.Value)
+	case *evaluator.LessThanOrEqualExpression:
+		return ex.Field + " <= " + valToString(ex.Value)
+	case *evaluator.AndExpression:
+		parts := make([]string, len(ex.Expressions))
+		for i, p := range ex.Expressions {
+			parts[i] = stringifyExpr(p.Expression)
+		}
+		return "(" + strings.Join(parts, " and ") + ")"
+	case *evaluator.OrExpression:
+		parts := make([]string, len(ex.Expressions))
+		for i, p := range ex.Expressions {
+			parts[i] = stringifyExpr(p.Expression)
+		}
+		return "(" + strings.Join(parts, " or ") + ")"
+	case *evaluator.NotExpression:
+		return "not " + stringifyExpr(ex.Expression.Expression)
+	default:
+		return ""
+	}
+}
+
+func valToString(v interface{}) string {
+	switch x := v.(type) {
+	case string:
+		return "\"" + x + "\""
+	case int, int64, float64, float32:
+		return fmt.Sprint(x)
+	case bool:
+		return fmt.Sprint(x)
+	default:
+		return fmt.Sprint(x)
+	}
+}

--- a/parser/simple/parser_test.go
+++ b/parser/simple/parser_test.go
@@ -1,0 +1,50 @@
+package simple
+
+import (
+	"reflect"
+	"testing"
+)
+
+type testUser struct {
+	Name  string
+	Age   int
+	Tags  []string
+	Score float64
+}
+
+func TestParseAndEvaluate(t *testing.T) {
+	expr := `Name is "bob" and Age > 30`
+	q, err := Parse(expr)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	u := &testUser{Name: "bob", Age: 35}
+	if !q.Evaluate(u) {
+		t.Errorf("evaluation failed")
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	exprs := []string{
+		`Name is "bob"`,
+		`Name is not "alice"`,
+		`Score >= 4.5`,
+		`Tags contains "go"`,
+		`not (Name is "alice")`,
+		`(Name is "bob" and Age > 30) or Score < 2`,
+	}
+	for _, e := range exprs {
+		q, err := Parse(e)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		s := Stringify(q)
+		q2, err := Parse(s)
+		if err != nil {
+			t.Fatalf("parse round: %v", err)
+		}
+		if !reflect.DeepEqual(q, q2) {
+			t.Errorf("round trip mismatch for %s", e)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a functional lexer and parser under `parser/simple`
- provide a `Stringify` function for round trips
- cover the parser with unit tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686518c15ef4832fb25f17afe6226ad6