### PR TITLE
ci: fix git tag failure by forcing tag creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,7 +513,7 @@ jobs:
           go-version-file: go.mod
       - name: Tag commit for release (workflow_dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' && startsWith(inputs.mode, 'release-') }}
-        run: git tag ${{ needs.prepare-release-tag.outputs.release_tag }}
+        run: git tag -f ${{ needs.prepare-release-tag.outputs.release_tag }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
Update the `git tag` step in the GoReleaser job of `.github/workflows/ci.yml` to use the `-f` (force) flag. This prevents the pipeline from failing with "fatal: tag 'vX.Y.Z' already exists" if the tag was already fetched or created locally.

---
*PR created automatically by Jules for task [8767122043820122109](https://jules.google.com/task/8767122043820122109) started by @arran4*